### PR TITLE
Se agrega nombre Francisca Benavides al archivo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,4 @@ Participantes:
 * Lucia Galbiatti
 * Mercedes Vatalaro
 * Rocio Magnarelli
+* Francisca Benavides


### PR DESCRIPTION
Actualicé el nombre pero no vi el de Paloma que estaba después de Rocío, la lista solo llegaba hasta Rocío así que imagino que habrá que editar después.